### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ viewpager实现的Gallery库
 项目分为app(demo工程)，mylib(依赖库工程)  
 Gallery的item可以自定义布局
 
-###Gallery库的使用
+### Gallery库的使用
 ##### 直接使用
 
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
